### PR TITLE
Fix missing manager tab

### DIFF
--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -602,12 +602,12 @@ class HybridAuth
     public function regManagerTab($controller, $user)
     {
         $this->config['user_id'] = $user->id;
+        $controller->addLexiconTopic('hybridauth:default');
         $controller->addCss($this->config['cssUrl'] . 'mgr/main.css');
         $controller->addCss($this->config['cssUrl'] . 'mgr/bootstrap.buttons.css');
         $controller->addJavascript($this->config['jsUrl'] . 'mgr/hybridauth.js');
         $controller->addJavascript($this->config['jsUrl'] . 'mgr/misc/utils.js');
         $controller->addJavascript($this->config['jsUrl'] . 'mgr/widgets/service.grid.js');
         $controller->addHtml('<script>HybridAuth.config=' . json_encode($this->config) . '</script>');
-        $controller->addLexiconTopic('hybridauth:default');
     }
 }


### PR DESCRIPTION
Loads the lexicon before the javascript, allowing the auth services tab panel to be rendered

### Why is it needed?
The services tab does not appear because the lexicon is currently loaded too late. The Ext tabs config requires a non-empty value for its `title` property, otherwise the tab and its panel won't render .

### How to test
Verify the tab shows up for users that log in via hybridauth.

### Related issue(s)/PR(s)
No related issue
