### PR TITLE
fix used modx tags in provider urls

### DIFF
--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -441,6 +441,7 @@ class HybridAuth
         $request = preg_replace('#^' . $this->modx->getOption('base_url') . '#', '', $_SERVER['REQUEST_URI']);
         $url = $this->modx->getOption('site_url') . ltrim(rawurldecode($request), '/');
         $url = preg_replace('#["\']#', '', strip_tags($url));
+        $url = preg_replace('#\[\[.*?\]\]#', '', strip_tags($url));
 
         $url .= strpos($url, '?')
             ? '&amp;hauth_action='

--- a/core/components/hybridauth/model/hybridauth/hybridauth.class.php
+++ b/core/components/hybridauth/model/hybridauth/hybridauth.class.php
@@ -441,7 +441,7 @@ class HybridAuth
         $request = preg_replace('#^' . $this->modx->getOption('base_url') . '#', '', $_SERVER['REQUEST_URI']);
         $url = $this->modx->getOption('site_url') . ltrim(rawurldecode($request), '/');
         $url = preg_replace('#["\']#', '', strip_tags($url));
-        $url = preg_replace('#\[\[.*?\]\]#', '', strip_tags($url));
+        $url = preg_replace('#\[\[.*?\]\]#', '', $url);
 
         $url .= strpos($url, '?')
             ? '&amp;hauth_action='


### PR DESCRIPTION
### Что оно делает?
Удаляет все вхождения [[ЧТО_УГОДНО]]

### Зачем это нужно?
Если открыть страницу на которой подключается Авторизация через провайдеров и в ссылке добавить ?[[++emailsender]], то в ссылках провайдеров мы увидим значение системной настройки.
